### PR TITLE
Fix all bugs

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,6 +19,8 @@ import queue
 import uuid
 
 # Import required libraries with error handling
+GUI_AVAILABLE = True
+GUI_IMPORT_ERROR = None
 try:
     from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
                                  QHBoxLayout, QGridLayout, QLabel, QPushButton, 
@@ -29,10 +31,20 @@ try:
     from PySide6.QtCore import Qt, QTimer, QThread, Signal, QSize, QRect, QEvent
     from PySide6.QtGui import (QPixmap, QImage, QFont, QIcon, QPalette, QColor,
                               QPainter, QPen, QBrush)
-except ImportError as e:
-    print(f"Required library not found: {e}")
-    print("Please install required packages: pip install -r requirements.txt")
-    sys.exit(1)
+except Exception as e:  # Catch broader errors like missing libEGL
+    # Defer GUI usage to runtime; allow headless/server-only imports
+    GUI_AVAILABLE = False
+    GUI_IMPORT_ERROR = e
+    class _QtDummy:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __call__(self, *args, **kwargs):
+            return self
+        def __getattr__(self, name):
+            return self
+    QApplication = QMainWindow = QWidget = QVBoxLayout = QHBoxLayout = QGridLayout = QLabel = QPushButton = QTextEdit = QTabWidget = QSplitter = QScrollArea = QFrame = QGroupBox = QTableWidget = QTableWidgetItem = QHeaderView = QProgressBar = QStatusBar = QMenuBar = QMessageBox = QInputDialog = QFileDialog = QSlider = _QtDummy
+    Qt = QTimer = QThread = Signal = QSize = QRect = QEvent = _QtDummy
+    QPixmap = QImage = QFont = QIcon = QPalette = QColor = QPainter = QPen = QBrush = _QtDummy
 
 # Import our custom modules
 try:
@@ -4752,24 +4764,31 @@ class MonitoringServerGUI(QMainWindow):
             event.accept()
 
 def main():
-    """Main entry point for the monitoring server."""
+    """Main entry point for the monitoring server.
+
+    If the GUI stack is unavailable (e.g., missing libEGL in headless CI), start server in headless mode.
+    """
     try:
-        # Create Qt application
-        app = QApplication(sys.argv)
-        
-        # Set application style
-        app.setStyle('Fusion')
-        
-        # Create server instance
-        server = MonitoringServer()
-        
-        # Create and show GUI
-        gui = MonitoringServerGUI(server)
-        gui.show()
-        
-        # Start event loop
-        sys.exit(app.exec())
-        
+        if GUI_AVAILABLE:
+            app = QApplication(sys.argv)
+            app.setStyle('Fusion')
+            server = MonitoringServer()
+            gui = MonitoringServerGUI(server)
+            gui.show()
+            sys.exit(app.exec())
+        else:
+            logger.warning(f"GUI unavailable ({GUI_IMPORT_ERROR}). Starting in headless mode.")
+            server = MonitoringServer()
+            server.start()
+            # Keep process alive; minimal loop
+            try:
+                while True:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                pass
+            finally:
+                server.stop()
+                sys.exit(0)
     except Exception as e:
         logger.error(f"Application failed: {e}")
         sys.exit(1)


### PR DESCRIPTION
Enable headless server operation by gracefully handling missing GUI dependencies and falling back to a non-GUI mode.

Previously, the server would hard-exit if PySide6 or its underlying system libraries (like libEGL) were not found, preventing it from running in environments without a display or full GUI stack (e.g., CI/CD pipelines, production servers). This change introduces a `GUI_AVAILABLE` flag and dummy Qt shims to allow the `server.py` module to import successfully, and the `main()` function now conditionally starts the GUI or runs the server in a headless, console-only mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-a84ac525-992c-4bbe-8c78-c026c9c16d1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a84ac525-992c-4bbe-8c78-c026c9c16d1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

